### PR TITLE
Removing the PBS port exposure seems to fix the torque health check

### DIFF
--- a/xenon-torque/Dockerfile
+++ b/xenon-torque/Dockerfile
@@ -31,12 +31,6 @@ ADD docker_entrypoint.sh /docker_entrypoint.sh
 
 # Expose sshd port
 EXPOSE 22
-# Expose pbs_server port
-#EXPOSE 15001
-# Expose pbs_mon port
-#EXPOSE 15002
-# Expose pbs_sched port
-#EXPOSE 15002
 
 # define the test that tells us if the docker container is healthy
 # ping ssh and pbs node

--- a/xenon-torque/Dockerfile
+++ b/xenon-torque/Dockerfile
@@ -32,11 +32,11 @@ ADD docker_entrypoint.sh /docker_entrypoint.sh
 # Expose sshd port
 EXPOSE 22
 # Expose pbs_server port
-EXPOSE 15001
+#EXPOSE 15001
 # Expose pbs_mon port
-EXPOSE 15002
+#EXPOSE 15002
 # Expose pbs_sched port
-EXPOSE 15002
+#EXPOSE 15002
 
 # define the test that tells us if the docker container is healthy
 # ping ssh and pbs node


### PR DESCRIPTION
If I remove the exposure of the PBS port, the torque docker image seems to work fine in xenon. Why are these ports exposed ? 